### PR TITLE
Added support for the modified wysiwyg() function

### DIFF
--- a/e_footer.php
+++ b/e_footer.php
@@ -198,7 +198,8 @@ class simplemde_footer
 			$enable = true;
 		}
 
-		if($enable === true && e107::wysiwyg() === true && check_class($this->corePrefs['post_html']))
+		//if($enable === true && e107::wysiwyg() === true && check_class($this->corePrefs['post_html']))
+		if($enable === true && e107::wysiwyg(null, true) === 'simplemde' && check_class($this->corePrefs['post_html']))
 		{
 			return true;
 		}

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 	<author name="Lóna Lore" url="https://lonalore.hu"/>
 	<summary lan="LAN_PLUGIN_SIMPLEMDE_SUMM">e107 integration for SimpleMDE Markdown Editor</summary>
 	<description lan="LAN_PLUGIN_SIMPLEMDE_DESC">A drop-in JavaScript textarea replacement for writing beautiful and understandable Markdown. The WYSIWYG-esque editor allows users who may be less experienced with Markdown to use familiar toolbar buttons and shortcuts. In addition, the syntax is rendered while editing to clearly show the expected result. Headings are larger, emphasized words are italicized, links are underlined, etc. SimpleMDE is one of the first editors to feature both built-in autosaving and spell checking.</description>
-	<category>content</category>
+	<category>misc</category>
 	<keywords>
 		<word>simplemde</word>
 		<word>markdown</word>


### PR DESCRIPTION
1. The core wysiwyg() function has changed and is now able to return the name of the wysiwyg editor to use on the page. e.g. when called this way: `wysiwyg('simplemde', true)` it will return the name of the editor. So in this case 'simplemde' in case 'simplemde' is installed. If it's not installed, it will return the name of the next installed wysiwyg editor (e.g. 'tinymce4') or falls back to 'bbcode'.
I've changed your call to this function in e_footer.php from `wysiwyg() === true` to `wysiwyg(null, true) === 'simplemde'` to make sure, the 'simplemde' js and css is only loaded when required.
2. I changed category from "content" to "misc" (like TinyMCE)